### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/01-fun.t
+++ b/t/01-fun.t
@@ -7,9 +7,9 @@ my $c = Acme::Meow.new;
 ok $c.can('feed'), 'We can feed the cat';
 ok $c.can('pet'), 'We can pet the cat';
 
-lives_ok { $c.feed }, 'feeding works';
-lives_ok { $c.feed('nip') }, 'feeding nip works';
-lives_ok { $c.feed('milk') }, 'feeding milk works';
-lives_ok { $c.pet  }, 'petting works';
+lives-ok { $c.feed }, 'feeding works';
+lives-ok { $c.feed('nip') }, 'feeding nip works';
+lives-ok { $c.feed('milk') }, 'feeding milk works';
+lives-ok { $c.pet  }, 'petting works';
 
 done;


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.